### PR TITLE
import locale for locale.format()

### DIFF
--- a/mentalist/view/base_words.py
+++ b/mentalist/view/base_words.py
@@ -2,6 +2,7 @@ import tkinter as Tk
 import tkinter.filedialog
 import tkinter.messagebox
 
+import locale
 from functools import partial
 
 from .base import BaseNode


### PR DESCRIPTION
locale.format() is called on line 136 but locale is never imported.